### PR TITLE
foi criado um time de 500ms para finalizar o envio da resposta, foi n…

### DIFF
--- a/CORE/Source/uRESTDWBase.pas
+++ b/CORE/Source/uRESTDWBase.pas
@@ -13291,8 +13291,10 @@ Begin
               AResponseInfo.WriteHeader;
             If Not (vBinaryEvent) Then
              If (Assigned(AResponseInfo.ContentStream)) Then
-              If AResponseInfo.ContentStream.size > 0   Then
+              If AResponseInfo.ContentStream.size > 0   Then Begin
                AResponseInfo.WriteContent;
+			         Sleep(500); //jcariasbr
+			        End;
           End;
         End;
       Finally


### PR DESCRIPTION
…ecessário para o cliente receber e processar a resposta e não gerar o erro quando o JSON de retorno for muito extenso. Foi testado em Javascript, Delphi, React-Native e webpascal, em todos os casos houve uma melhora na qualidade da resposta