### PR TITLE
Corrigindo erro Access Violation ao indicar ParamByName

### DIFF
--- a/CORE/Source/Basic/uRESTDWBasicDB.pas
+++ b/CORE/Source/Basic/uRESTDWBasicDB.pas
@@ -7975,15 +7975,18 @@ Begin
            If vError Then
             Begin
              vInBlockEvents := False;
+
+             If Assigned(vOnGetDataError) Then
+              vOnGetDataError(False, vErrorMSG);
+             If vRaiseError Then
+              Raise Exception.Create(PChar(vErrorMSG));
+
              If ReleaseCache Then
               Begin
                TMassiveDatasetBuffer(vMassiveDataset).ClearBuffer;
                RebuildMassiveDataset;
               End;
-             If Assigned(vOnGetDataError) Then
-              vOnGetDataError(False, vErrorMSG);
-             If vRaiseError Then
-              Raise Exception.Create(PChar(vErrorMSG));
+             
             End;
           End;
          If Assigned(vResult) Then

--- a/CORE/Source/Basic/uRESTDWBasicDB.pas
+++ b/CORE/Source/Basic/uRESTDWBasicDB.pas
@@ -8047,6 +8047,8 @@ Begin
      Break;
     End;
   End;
+  if Result = nil then 
+    raise Exception.Create('Parâmetro ''' + Value + ''' não encontrado.');
 End;
 
 Function TRESTDWTable.ParamCount: Integer;

--- a/CORE/Source/Basic/uRESTDWBasicDB.pas
+++ b/CORE/Source/Basic/uRESTDWBasicDB.pas
@@ -494,7 +494,7 @@ Type
   Procedure   OpenDatasets          (Datasets               : Array of {$IFDEF FPC}TRESTDWClientSQLBase{$ELSE}TObject{$ENDIF};
                                      Var   Error            : Boolean;
                                      Var   MessageError     : String;
-                                     BinaryRequest          : Boolean = True);Overload;
+                                     BinaryRequest          : Boolean = True);Overload; virtual;
   Function    GetTableNames         (Var   TableNames       : TStringList)  : Boolean;
   Function    GetFieldNames         (TableName              : String;
                                      Var FieldNames         : TStringList)  : Boolean;
@@ -846,7 +846,7 @@ Type
   Function    ExecSQL          (Var Error : String) : Boolean;Overload;//Método ExecSQL que será utilizado no Componente
   Function    InsertMySQLReturnID : Integer;                     //Método de ExecSQL com retorno de Incremento
   Function    ParamByName          (Value : String) : TParam;    //Retorna o Parametro de Acordo com seu nome
-  Procedure   ApplyUpdates;Overload;
+  Procedure   ApplyUpdates;Overload; Virtual;
   Function    ApplyUpdates     (Var Error : String; ReleaseCache : Boolean = True) : Boolean;Overload;//Aplica Alterações no Banco de Dados
   Constructor Create              (AOwner : TComponent);Override;//Cria o Componente
   Destructor  Destroy;Override;                                  //Destroy a Classe

--- a/CORE/Source/Basic/uRESTDWBasicDB.pas
+++ b/CORE/Source/Basic/uRESTDWBasicDB.pas
@@ -8024,6 +8024,8 @@ Begin
      Break;
     End;
   End;
+  if Result = nil then 
+    raise Exception.Create('Parâmetro ''' + Value + ''' não encontrado.');
 End;
 
 Function TRESTDWClientSQL.ParamByName(Value: String): TParam;


### PR DESCRIPTION
São 3 alterações:   
 - o Access Violation,  
 - Ajuste para permitir inherited
 - Correção para permitir gravação quando houver Trigger na tabela no SQL-Server

Corrigindo erro de Access Violation ao indicar um parâmetro que não existe, na propriedade ParamByName do TRESTDWClientSQL.

Correção seguindo a mesma lógica do Standard do FireDac:

             function TFDDataSet.ParamByName(const AValue: string): TFDParam;
             begin
               Result := Params.ParamByName(AValue);
             end;

             function TFDParams.ParamByName(const AValue: String): TFDParam;
             begin
               Result := FindParam(AValue);
               if Result = nil then
                 DatabaseErrorFmt(SParameterNotFound, [AValue], GetDataSet);
             end;
