### PR TITLE
Permitir cases diferentes do JSON de retorno do JSONValue 

### DIFF
--- a/CORE/Source/Consts/uRESTDWConsts.pas
+++ b/CORE/Source/Consts/uRESTDWConsts.pas
@@ -321,6 +321,7 @@ Type
                      ovLongWord,        ovShortint,     ovByte, ovExtended, ovConnection, ovParams,    ovStream,             //42..48
                      ovTimeStampOffset, ovObject,       ovSingle);                                                           //49..51
  TDatasetType     = (dtReflection,      dtFull,         dtDiff);
+ TCaseType        = (ctNone,            ctUpperCase,    ctLowerCase,        ctCamelCase);
  Function  GetObjectName            (TypeObject         : TTypeObject)            : String;          Overload;
  Function  GetDataModeName          (TypeObject         : TDataMode)              : String;          Overload;
  Function  GetDataModeName          (TypeObject         : String)                 : TDataMode;       Overload;

--- a/CORE/Source/utils/uRESTDWJSONObject.pas
+++ b/CORE/Source/utils/uRESTDWJSONObject.pas
@@ -1773,12 +1773,14 @@ Procedure TJSONValue.LoadFromDataset(TableName        : String;
                                      HeaderLowercase  : Boolean = False);
 Var
  I: Integer;
- vText: TArray<Char>;
  vTagGeral : String;
  {$IFNDEF FPC}
+ vText: TArray<Char>;
  {$IF CompilerVersion < 22} // Delphi 2010 pra cima
  vSizeChar : Integer;
  {$IFEND}
+ {$ELSE}
+ vText: TCharArray;
  {$ENDIF}
 Begin
  // Recebe o parametro "DataType" para fazer a tipagem na função que gera a linha "GenerateLine"
@@ -1807,8 +1809,8 @@ Begin
    Begin
     vText     := vTagGeral.ToCharArray;
     vTagGeral := '';
-    I := Low(vText);
-    While I <= High(vText) Do
+    I := InitStrPos;
+    While I <= Length(vText)-1 Do
     Begin
      If (vText[I] = '_') Or (vText[I] = '"') Or (vText[I -1] = '"') then
      Begin

--- a/CORE/Source/utils/uRESTDWJSONObject.pas
+++ b/CORE/Source/utils/uRESTDWJSONObject.pas
@@ -1805,17 +1805,8 @@ Begin
    vTagGeral := LowerCase(vTagGeral);
   ctCamelCase:
    Begin
-    If vtagName = '' Then
-    Begin
-     vTagGeral := Copy(vTagGeral, 3, Length(vTagGeral));
-     vText     := vTagGeral.ToCharArray;
-     vTagGeral := '[{';
-    End
-    Else
-    Begin
-     vText     := vTagGeral.ToCharArray;
-     vTagGeral := '';
-    End;
+    vText     := vTagGeral.ToCharArray;
+    vTagGeral := '';
     I := Low(vText);
     While I <= High(vText) Do
     Begin
@@ -1833,7 +1824,7 @@ Begin
      End
      Else
      Begin
-      If (CaseType = ctCamelCase) And (I = 0) Then
+      If I = 0 Then
        vTagGeral := vTagGeral + UpperCase(vText[I])
       Else
        vTagGeral := vTagGeral + LowerCase(vText[I]);

--- a/CORE/Source/utils/uRESTDWJSONObject.pas
+++ b/CORE/Source/utils/uRESTDWJSONObject.pas
@@ -1774,13 +1774,11 @@ Procedure TJSONValue.LoadFromDataset(TableName        : String;
 Var
  I: Integer;
  vTagGeral : String;
+ vText     : String;
  {$IFNDEF FPC}
- vText: TArray<Char>;
  {$IF CompilerVersion < 22} // Delphi 2010 pra cima
  vSizeChar : Integer;
  {$IFEND}
- {$ELSE}
- vText: TCharArray;
  {$ENDIF}
 Begin
  // Recebe o parametro "DataType" para fazer a tipagem na função que gera a linha "GenerateLine"
@@ -1807,7 +1805,7 @@ Begin
    vTagGeral := LowerCase(vTagGeral);
   ctCamelCase:
    Begin
-    vText     := vTagGeral.ToCharArray;
+    vText     := vTagGeral;
     vTagGeral := '';
     I := InitStrPos;
     While I <= Length(vText)-1 Do


### PR DESCRIPTION
Permitir escolher entre UPPERCASE, lowercase e CamelCase no Retorno do JSONValue quando é usado o .LoadFromDataSet