### PR TITLE
- Correção do PhysFireDAC - Tratamento de Exceções

### DIFF
--- a/CORE/Source/Database_Drivers/FireDACPhysLink/FireDAC.Phys.RESTDWBase.pas
+++ b/CORE/Source/Database_Drivers/FireDACPhysLink/FireDAC.Phys.RESTDWBase.pas
@@ -612,8 +612,6 @@ begin
 
     if not vError then begin
       Result := vRowsAffected;
-      if exec then
-        Result := vRowsAffected;
     end
     else begin
       Result := 0;


### PR DESCRIPTION
- Correção da Exceção do ExecuteCommand para receber no ApplyUpdates do FDTable (Ao se conectar usando Autenticação (Bearer ou Token), sem RenewToken, com LifeCycle=10), forçando o Servidor a dar erro 401 - Unauthorized e não gravar o registro no banco e sim dar a mensagem de exceção) ->> by Eloy (rsrsrsrsrs)