### PR TITLE
- SQLEditor abrindo sem travar

### DIFF
--- a/CORE/Source/Plugins/SQLEditor/uRESTDWSqlEditor.dfm
+++ b/CORE/Source/Plugins/SQLEditor/uRESTDWSqlEditor.dfm
@@ -13,6 +13,7 @@ object FrmDWSqlEditor: TFrmDWSqlEditor
   Font.Style = []
   OldCreateOrder = False
   Position = poScreenCenter
+  OnActivate = FormActivate
   OnClose = FormClose
   OnCreate = FormCreate
   OnShow = FormShow
@@ -301,5 +302,12 @@ object FrmDWSqlEditor: TFrmDWSqlEditor
         TitleFont.Style = []
       end
     end
+  end
+  object tmClose: TTimer
+    Enabled = False
+    Interval = 200
+    OnTimer = tmCloseTimer
+    Left = 341
+    Top = 240
   end
 end

--- a/CORE/Source/Plugins/SQLEditor/uRESTDWSqlEditor.lfm
+++ b/CORE/Source/Plugins/SQLEditor/uRESTDWSqlEditor.lfm
@@ -1,7 +1,7 @@
 object FrmDWSqlEditor: TFrmDWSqlEditor
-  Left = 551
+  Left = 472
   Height = 756
-  Top = 130
+  Top = 195
   Width = 1079
   BorderWidth = 5
   Caption = 'RESTDWClientSQL Editor'
@@ -11,6 +11,7 @@ object FrmDWSqlEditor: TFrmDWSqlEditor
   Font.Color = clWindowText
   Font.Height = -11
   Font.Name = 'Tahoma'
+  OnActivate = FormActivate
   OnClose = FormClose
   OnCreate = FormCreate
   OnShow = FormShow
@@ -311,5 +312,12 @@ object FrmDWSqlEditor: TFrmDWSqlEditor
         TitleFont.Name = 'Tahoma'
       end
     end
+  end
+  object tmClose: TTimer
+    Enabled = False
+    Interval = 200
+    OnTimer = tmCloseTimer
+    Left = 341
+    Top = 240
   end
 end


### PR DESCRIPTION
- Alteração na escrita da propriedade SQL do RESTDWClientSQL, permitindo escrever sem user SQLEditor
- SQLEditor abrindo sem travar, por falhas de não estar conectado
- Adaptado thread para buscar Tables e Fields no SQLEditor