### PR TITLE
PhysFireDAC - Erro campo InternalCalc

### DIFF
--- a/CORE/Source/Database_Drivers/FireDACPhysLink/FireDAC.Phys.RESTDWBase.pas
+++ b/CORE/Source/Database_Drivers/FireDACPhysLink/FireDAC.Phys.RESTDWBase.pas
@@ -760,6 +760,9 @@ var
 begin
   Result := null;
 
+  if col >= FFieldCount then
+    Exit;
+
   FStream.Read(vBoolean, Sizeof(Byte));
 
   // is null


### PR DESCRIPTION
- Correção de campo InternalCalc no PhysFireDAC