### PR TITLE
Server Drivers com query Unidirecional + RESTDWMemoryDataset 95% Pronto

### DIFF
--- a/CORE/Source/Basic/uRESTDWParams.pas
+++ b/CORE/Source/Basic/uRESTDWParams.pas
@@ -1551,7 +1551,10 @@ Begin
  Try
   If Not bValue.Active Then
    bValue.Open;
-  bValue.First;
+
+  if not bValue.IsUniDirectional then
+    bValue.First;
+
   {$IFDEF FPC}
   vBuildSide := 'L';
   {$ELSE}

--- a/CORE/Source/Basic/uRESTDWStorageBin.pas
+++ b/CORE/Source/Basic/uRESTDWStorageBin.pas
@@ -707,7 +707,8 @@ var
   vByte : byte;
   vBookMark : TBookmark;
 begin
-  AStream.Size := 0;
+  //  AStream.Size := 0; // TBufferedFileStream nao funciona no lazarus
+  AStream.Seek(0,soBeginning);
   if not ADataset.Active then
     ADataset.Open
   else
@@ -758,15 +759,17 @@ begin
   AStream.WriteBuffer(vRecordCount,SizeOf(Longint));
   vBookMark := ADataset.GetBookmark;
   ADataset.DisableControls;
-  // fetchall
-  ADataset.Last;
-  ADataset.First;
+
+  if not ADataset.IsUniDirectional then
+    ADataset.First;
+
   vRecordCount := 0;
   while not ADataset.Eof do begin
     SaveRecordToStream(ADataset,AStream);
     ADataset.Next;
     vRecordCount := vRecordCount + 1;
   end;
+
   ADataset.GotoBookmark(vBookMark);
   ADataset.FreeBookmark(vBookMark);
   ADataset.EnableControls;
@@ -844,7 +847,7 @@ end;
 
 function TRESTDWStorageBin.SaveRecordDWMemToStream(IDataset: IRESTDWMemTable; var AStream: TStream) : Longint;
 var
-  ADataSet      : TRESTDWMemTable;
+  ADataSet : TRESTDWMemTable;
   i : Longint;
   j : integer;
   vFieldSize : integer;

--- a/CORE/Source/Database_Drivers/uRESTDWAnyDACDriver.pas
+++ b/CORE/Source/Database_Drivers/uRESTDWAnyDACDriver.pas
@@ -4,7 +4,7 @@
 
 {
   REST Dataware .
-  Criado por XyberX (Gilbero Rocha da Silva), o REST Dataware tem como objetivo o uso de REST/JSON
+  Criado por XyberX (Gilberto Rocha da Silva), o REST Dataware tem como objetivo o uso de REST/JSON
  de maneira simples, em qualquer Compilador Pascal (Delphi, Lazarus e outros...).
   O REST Dataware também tem por objetivo levar componentes compatíveis entre o Delphi e outros Compiladores
  Pascal e com compatibilidade entre sistemas operacionais.
@@ -94,6 +94,7 @@ type
     function getConectionType : TRESTDWDatabaseType; override;
   public
     function getQuery : TRESTDWDrvQuery; override;
+    function getQuery(AUnidir : boolean) : TRESTDWDrvQuery; override;
     function getTable : TRESTDWDrvTable; override;
     function getStoreProc : TRESTDWDrvStoreProc; override;
 
@@ -193,6 +194,15 @@ begin
   qry.FormatOptions.StrsTrim2Len   := StrsTrim2Len;
 
   Result := TRESTDWAnyDACQuery.Create(qry);
+end;
+
+function TRESTDWAnyDACDriver.getQuery(AUnidir : boolean) : TRESTDWDrvQuery;
+var
+  qry : TADQuery;
+begin
+  Result := inherited getQuery(AUnidir);
+  qry := TADQuery(Result.Owner);
+  qry.FetchOptions.Unidirectional := AUnidir;
 end;
 
 function TRESTDWAnyDACDriver.getTable : TRESTDWDrvTable;

--- a/CORE/Source/Database_Drivers/uRESTDWDriverBase.pas
+++ b/CORE/Source/Database_Drivers/uRESTDWDriverBase.pas
@@ -256,7 +256,8 @@ Type
   Function compConnIsValid(comp : TComponent) : boolean; virtual;
   Function  getConectionType : TRESTDWDatabaseType; Virtual;
   Function  getDatabaseInfo  : TRESTDWDatabaseInfo; Virtual;
-  Function  getQuery         : TRESTDWDrvQuery;   Virtual;
+  Function  getQuery : TRESTDWDrvQuery; Overload; Virtual;
+  Function  getQuery(AUnidir : boolean) : TRESTDWDrvQuery; Overload; Virtual;
   Function  getTable         : TRESTDWDrvTable;   Virtual;
   Function  getStoreProc     : TRESTDWDrvStoreProc;   Virtual;
   Procedure Connect;                                Virtual;
@@ -915,12 +916,12 @@ End;
 
 { TRESTDWDriverBase }
 
-Function TRESTDWDriverBase.getConectionType : TRESTDWDatabaseType;
+function TRESTDWDriverBase.getConectionType : TRESTDWDatabaseType;
 Begin
  Result := dbtUndefined;
 End;
 
-Function TRESTDWDriverBase.getDatabaseInfo  : TRESTDWDatabaseInfo;
+function TRESTDWDriverBase.getDatabaseInfo : TRESTDWDatabaseInfo;
 Var
  connType : TRESTDWDatabaseType;
  qry      : TRESTDWDrvQuery;
@@ -1131,37 +1132,43 @@ Begin
  End;
 End;
 
-Function TRESTDWDriverBase.getQuery: TRESTDWDrvQuery;
+function TRESTDWDriverBase.getQuery : TRESTDWDrvQuery;
 Begin
  Result := Nil;
 End;
 
-Function TRESTDWDriverBase.getTable: TRESTDWDrvTable;
+function TRESTDWDriverBase.getQuery(AUnidir : boolean) : TRESTDWDrvQuery;
+begin
+ // implementada em alguns drivers
+ Result := getQuery();
+end;
+
+function TRESTDWDriverBase.getTable : TRESTDWDrvTable;
 Begin
  Result := Nil;
 End;
 
-Function TRESTDWDriverBase.getStoreProc : TRESTDWDrvStoreProc;
+function TRESTDWDriverBase.getStoreProc : TRESTDWDrvStoreProc;
 Begin
  Result := Nil;
 End;
 
-Function TRESTDWDriverBase.isConnected: boolean;
+function TRESTDWDriverBase.isConnected : Boolean;
 Begin
  Result := False;
 End;
 
-Function TRESTDWDriverBase.connInTransaction: boolean;
+function TRESTDWDriverBase.connInTransaction : Boolean;
 Begin
  Result := False;
 End;
 
-Procedure TRESTDWDriverBase.connStartTransaction;
+procedure TRESTDWDriverBase.connStartTransaction;
 Begin
 
 End;
 
-Procedure TRESTDWDriverBase.connRollback;
+procedure TRESTDWDriverBase.connRollback;
 Begin
 
 End;
@@ -1171,12 +1178,12 @@ begin
   Result := False;
 end;
 
-Procedure TRESTDWDriverBase.connCommit;
+procedure TRESTDWDriverBase.connCommit;
 Begin
 
 End;
 
-Function TRESTDWDriverBase.isMinimumVersion(major, minor, sub: integer): boolean;
+function TRESTDWDriverBase.isMinimumVersion(major, minor, sub : Integer) : Boolean;
 Var
  info : TRESTDWDatabaseInfo;
 Begin
@@ -1186,12 +1193,12 @@ Begin
            (info.rdwDatabaseMinorVersion >= sub);
 End;
 
-Function TRESTDWDriverBase.isMinimumVersion(major, minor: integer): boolean;
+function TRESTDWDriverBase.isMinimumVersion(major, minor : Integer) : Boolean;
 Begin
  Result := isMinimumVersion(major, minor, 0);
 End;
 
-Procedure TRESTDWDriverBase.setConnection(AValue: TComponent);
+procedure TRESTDWDriverBase.setConnection(AValue : TComponent);
 Begin
  If FConnection = AValue Then
   Exit;
@@ -1387,7 +1394,7 @@ begin
   end;
 end;
 
-Procedure TRESTDWDriverBase.Connect;
+procedure TRESTDWDriverBase.Connect;
 Begin
 
 End;
@@ -1398,19 +1405,17 @@ begin
   inherited;
 end;
 
-Procedure TRESTDWDriverBase.Disconect;
+procedure TRESTDWDriverBase.Disconect;
 Begin
 
 End;
 
-Function TRESTDWDriverBase.ConnectionSet: Boolean;
+function TRESTDWDriverBase.ConnectionSet : Boolean;
 Begin
  Result := Assigned(FConnection);
 End;
 
-Function TRESTDWDriverBase.GetGenID(Query   : TRESTDWDrvQuery;
-                                    GenName : String;
-                                    valor   : Integer) : Integer;
+function TRESTDWDriverBase.GetGenID(Query : TRESTDWDrvQuery; GenName : String; valor : Integer) : Integer;
 Var
  connType : TRESTDWDatabaseType;
 Begin
@@ -1475,8 +1480,7 @@ Begin
   End;
 End;
 
-Function TRESTDWDriverBase.GetGenID(GenName : String;
-                                    valor   : Integer) : Integer;
+function TRESTDWDriverBase.GetGenID(GenName : String; valor : Integer) : Integer;
 Var
  qry : TRESTDWDrvQuery;
 Begin
@@ -1488,12 +1492,7 @@ Begin
  End;
 End;
 
-Function TRESTDWDriverBase.ApplyUpdates(MassiveStream    : TStream;
-                                        SQL              : String;
-                                        Params           : TRESTDWParams;
-                                        var Error        : Boolean;
-                                        var MessageError : String;
-                                        var RowsAffected : Integer) : TJSONValue;
+function TRESTDWDriverBase.ApplyUpdates(MassiveStream : TStream; SQL : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String; var RowsAffected : Integer) : TJSONValue;
 Var
  MassiveDataset : TMassiveDatasetBuffer;
 Begin
@@ -1507,12 +1506,7 @@ Begin
 End;
 
 
-Function TRESTDWDriverBase.ApplyUpdates(Massive,
-                                        SQL              : String;
-                                        Params           : TRESTDWParams;
-                                        Var Error        : Boolean;
-                                        Var MessageError : String;
-                                        Var RowsAffected : Integer): TJSONValue;
+function TRESTDWDriverBase.ApplyUpdates(Massive, SQL : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String; var RowsAffected : Integer) : TJSONValue;
 Var
  MassiveDataset : TMassiveDatasetBuffer;
 Begin
@@ -1525,12 +1519,7 @@ Begin
  End;
 End;
 
-Function TRESTDWDriverBase.ApplyUpdatesTB(MassiveStream    : TStream;
-                                          SQL              : String;
-                                          Params           : TRESTDWParams;
-                                          Var Error        : Boolean;
-                                          Var MessageError : String;
-                                          Var RowsAffected : Integer): TJSONValue;
+function TRESTDWDriverBase.ApplyUpdatesTB(MassiveStream : TStream; SQL : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String; var RowsAffected : Integer) : TJSONValue;
 Var
   vTempQuery         : TRESTDWDrvTable;
   vResultReflection  : String;
@@ -1909,11 +1898,7 @@ begin
   end;
 end;
 
-Function TRESTDWDriverBase.ApplyUpdatesTB(Massive          : String;
-                                          Params           : TRESTDWParams;
-                                          var Error        : Boolean;
-                                          var MessageError : String;
-                                          var RowsAffected : Integer): TJSONValue;
+function TRESTDWDriverBase.ApplyUpdatesTB(Massive : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String; var RowsAffected : Integer) : TJSONValue;
 var
   vTempQuery: TRESTDWDrvTable;
   vResultReflection : string;
@@ -2104,9 +2089,7 @@ begin
   end;
 end;
 
-Function TRESTDWDriverBase.ApplyUpdates_MassiveCache  (MassiveStream         : TStream;
-                                                       Var Error             : Boolean;
-                                                       Var MessageError      : String) : TJSONValue;
+function TRESTDWDriverBase.ApplyUpdates_MassiveCache(MassiveStream : TStream; var Error : Boolean; var MessageError : String) : TJSONValue;
 Var
  MassiveDataset : TMassiveDatasetBuffer;
  aMassive       : TStream;
@@ -2181,9 +2164,7 @@ Begin
  End;
 End;
 
-Function TRESTDWDriverBase.ApplyUpdates_MassiveCache  (MassiveDataset   : TMassiveDatasetBuffer;
-                                                       Var Error        : Boolean;
-                                                       Var MessageError : String): String;
+function TRESTDWDriverBase.ApplyUpdates_MassiveCache(MassiveDataset : TMassiveDatasetBuffer; var Error : Boolean; var MessageError : String) : String;
 var
  vTempQuery        : TRESTDWDrvQuery;
  vStateResource,
@@ -2292,9 +2273,7 @@ Begin
   End;
 end;
 
-Function TRESTDWDriverBase.ApplyUpdates_MassiveCache  (MassiveCache     : String;
-                                                       Var Error        : Boolean;
-                                                       Var MessageError : String): TJSONValue;
+function TRESTDWDriverBase.ApplyUpdates_MassiveCache(MassiveCache : String; var Error : Boolean; var MessageError : String) : TJSONValue;
 var
   vTempQuery: TRESTDWDrvQuery;
   vStateResource, vMassiveLine: boolean;
@@ -2438,23 +2417,17 @@ begin
   end;
 end;
 
-Function TRESTDWDriverBase.ApplyUpdates_MassiveCacheTB(MassiveStream         : TStream;
-                                                       Var Error             : Boolean;
-                                                       Var MessageError      : String) : TJSONValue;
+function TRESTDWDriverBase.ApplyUpdates_MassiveCacheTB(MassiveStream : TStream; var Error : Boolean; var MessageError : String) : TJSONValue;
 Begin
 
 End;
 
-Function TRESTDWDriverBase.ApplyUpdates_MassiveCacheTB(MassiveCache     : String;
-                                                       Var Error        : Boolean;
-                                                       Var MessageError : String): TJSONValue;
+function TRESTDWDriverBase.ApplyUpdates_MassiveCacheTB(MassiveCache : String; var Error : Boolean; var MessageError : String) : TJSONValue;
 Begin
 
 End;
 
-Function TRESTDWDriverBase.ProcessMassiveSQLCache(MassiveSQLCache: String;
-                                                  var Error: Boolean;
-                                                  var MessageError: String): TJSONValue;
+function TRESTDWDriverBase.ProcessMassiveSQLCache(MassiveSQLCache : String; var Error : Boolean; var MessageError : String) : TJSONValue;
 Var
  vTempQuery        : TRESTDWDrvQuery;
  vStateResource    : Boolean;
@@ -2558,30 +2531,15 @@ Begin
   End;
 end;
 
-Function TRESTDWDriverBase.ExecuteCommand(SQL                   : String;
-                                          Var Error             : Boolean;
-                                          Var MessageError      : String;
-                                          Var BinaryBlob        : TMemoryStream;
-                                          Var RowsAffected      : Integer;
-                                          Execute               : Boolean = False;
-                                          BinaryEvent           : Boolean = False;
-                                          MetaData              : Boolean = False;
-                                          BinaryCompatibleMode  : Boolean = False) : String;
+function TRESTDWDriverBase.ExecuteCommand(
+  SQL : String; var Error : Boolean; var MessageError : String; var BinaryBlob : TMemoryStream; var RowsAffected : Integer; Execute : Boolean; BinaryEvent : Boolean; MetaData : Boolean; BinaryCompatibleMode : Boolean) : String;
 Begin
  Result := ExecuteCommand(SQL, Nil, Error, MessageError, BinaryBlob, RowsAffected,
                           Execute, BinaryEvent, MetaData, BinaryCompatibleMode);
 End;
 
-Function TRESTDWDriverBase.ExecuteCommand(SQL                   : String;
-                                          Params                : TRESTDWParams;
-                                          Var Error             : Boolean;
-                                          Var MessageError      : String;
-                                          Var BinaryBlob        : TMemoryStream;
-                                          Var RowsAffected      : Integer;
-                                          Execute               : Boolean = False;
-                                          BinaryEvent           : Boolean = False;
-                                          MetaData              : Boolean = False;
-                                          BinaryCompatibleMode  : Boolean = False): String;
+function TRESTDWDriverBase.ExecuteCommand(
+  SQL : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String; var BinaryBlob : TMemoryStream; var RowsAffected : Integer; Execute : Boolean; BinaryEvent : Boolean; MetaData : Boolean; BinaryCompatibleMode : Boolean) : String;
 var
   vTempQuery: TRESTDWDrvQuery;
   vDataSet: TDataSet;
@@ -2592,7 +2550,7 @@ begin
   Error := False;
   Result := '';
   aResult := TJSONValue.Create;
-  vTempQuery := getQuery;
+  vTempQuery := getQuery(not Execute);
   vDataSet := TDataSet(vTempQuery.Owner);
   try
     vStateResource := isConnected;
@@ -2690,27 +2648,15 @@ begin
   FreeAndNil(vTempQuery);
 end;
 
-Function TRESTDWDriverBase.ExecuteCommandTB(Tablename: String;
-                                            var Error: Boolean;
-                                            var MessageError: String;
-                                            var BinaryBlob: TMemoryStream;
-                                            var RowsAffected: Integer;
-                                            BinaryEvent: Boolean;
-                                            MetaData: Boolean;
-                                            BinaryCompatibleMode: Boolean): String;
+function TRESTDWDriverBase.ExecuteCommandTB(
+  Tablename : String; var Error : Boolean; var MessageError : String; var BinaryBlob : TMemoryStream; var RowsAffected : Integer; BinaryEvent : Boolean; MetaData : Boolean; BinaryCompatibleMode : Boolean) : String;
 begin
   ExecuteCommandTB(Tablename,nil,Error,MessageError,BinaryBlob,RowsAffected,
                    BinaryEvent,MetaData,BinaryCompatibleMode);
 end;
 
-Function TRESTDWDriverBase.ExecuteCommandTB(Tablename: String;
-                                            Params: TRESTDWParams;
-                                            var Error: Boolean;
-                                            var MessageError: String;
-                                            var BinaryBlob: TMemoryStream;
-                                            var RowsAffected: Integer;
-                                            BinaryEvent: Boolean; MetaData: Boolean;
-                                            BinaryCompatibleMode: Boolean): String;
+function TRESTDWDriverBase.ExecuteCommandTB(
+  Tablename : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String; var BinaryBlob : TMemoryStream; var RowsAffected : Integer; BinaryEvent : Boolean; MetaData : Boolean; BinaryCompatibleMode : Boolean) : String;
 var
   vTempQuery     : TRESTDWDrvTable;
   vDataset       : TDataset;
@@ -2806,10 +2752,7 @@ begin
  vTempQuery.Free;
 end;
 
-Procedure TRESTDWDriverBase.ExecuteProcedure(ProcName         : String;
-                                             Params           : TRESTDWParams;
-                                             Var Error        : Boolean;
-                                             Var MessageError : String);
+procedure TRESTDWDriverBase.ExecuteProcedure(ProcName : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String);
 Var
  vStateResource  : Boolean;
  vTempStoredProc : TRESTDWDrvStoreProc;
@@ -2854,16 +2797,12 @@ Begin
   end;
 end;
 
-Procedure TRESTDWDriverBase.ExecuteProcedurePure(ProcName         : String;
-                                                 Var Error        : Boolean;
-                                                 Var MessageError : String);
+procedure TRESTDWDriverBase.ExecuteProcedurePure(ProcName : String; var Error : Boolean; var MessageError : String);
 Begin
  ExecuteProcedure(ProcName, nil, Error, MessageError);
 End;
 
-Procedure TRESTDWDriverBase.GetTableNames(Var TableNames   : TStringList;
-                                          Var Error        : Boolean;
-                                          Var MessageError : String);
+procedure TRESTDWDriverBase.GetTableNames(var TableNames : TStringList; var Error : Boolean; var MessageError : String);
 Var
  vStateResource : Boolean;
  connType : TRESTDWDatabaseType;
@@ -2959,10 +2898,7 @@ Begin
  End;
 End;
 
-Procedure TRESTDWDriverBase.GetFieldNames(TableName        : String;
-                                          Var FieldNames   : TStringList;
-                                          Var Error        : Boolean;
-                                          Var MessageError : String);
+procedure TRESTDWDriverBase.GetFieldNames(TableName : String; var FieldNames : TStringList; var Error : Boolean; var MessageError : String);
 Var
  vStateResource : Boolean;
  connType       : TRESTDWDatabaseType;
@@ -3060,10 +2996,7 @@ Begin
  End;
 end;
 
-Procedure TRESTDWDriverBase.GetKeyFieldNames(TableName        : String;
-                                             Var FieldNames   : TStringList;
-                                             Var Error        : Boolean;
-                                             Var MessageError : String);
+procedure TRESTDWDriverBase.GetKeyFieldNames(TableName : String; var FieldNames : TStringList; var Error : Boolean; var MessageError : String);
 Var
  vStateResource : Boolean;
  connType       : TRESTDWDatabaseType;
@@ -3224,9 +3157,7 @@ Begin
  End;
 End;
 
-Procedure TRESTDWDriverBase.GetProcNames(Var ProcNames    : TStringList;
-                                         Var Error        : Boolean;
-                                         Var MessageError : String);
+procedure TRESTDWDriverBase.GetProcNames(var ProcNames : TStringList; var Error : Boolean; var MessageError : String);
 Var
  vStateResource : Boolean;
  connType       : TRESTDWDatabaseType;
@@ -3308,10 +3239,7 @@ Begin
  End;
 End;
 
-Procedure TRESTDWDriverBase.GetProcParams(ProcName         : String;
-                                          Var ParamNames   : TStringList;
-                                          Var Error        : Boolean;
-                                          Var MessageError : String);
+procedure TRESTDWDriverBase.GetProcParams(ProcName : String; var ParamNames : TStringList; var Error : Boolean; var MessageError : String);
 Var
  vStateResource : Boolean;
  connType       : TRESTDWDatabaseType;
@@ -3657,17 +3585,12 @@ Begin
  End;
 End;
 
-Function TRESTDWDriverBase.InsertMySQLReturnID(SQL              : String;
-                                               Var Error        : Boolean;
-                                               Var MessageError : String) : Integer;
+function TRESTDWDriverBase.InsertMySQLReturnID(SQL : String; var Error : Boolean; var MessageError : String) : Integer;
 Begin
  Result := InsertMySQLReturnID(SQL, Nil, Error, MessageError);
 End;
 
-Function TRESTDWDriverBase.InsertMySQLReturnID(SQL              : String;
-                                               Params           : TRESTDWParams;
-                                               var Error        : Boolean;
-                                               var MessageError : String) : Integer;
+function TRESTDWDriverBase.InsertMySQLReturnID(SQL : String; Params : TRESTDWParams; var Error : Boolean; var MessageError : String) : Integer;
 Var
  vTempQuery     : TRESTDWDrvQuery;
  vStateResource : Boolean;
@@ -3715,10 +3638,7 @@ Begin
  FreeAndNil(vTempQuery);
 End;
 
-Function TRESTDWDriverBase.OpenDatasets(DatasetsLine     : String;
-                                        var Error        : Boolean;
-                                        var MessageError : String;
-                                        var BinaryBlob   : TMemoryStream): TJSONValue;
+function TRESTDWDriverBase.OpenDatasets(DatasetsLine : String; var Error : Boolean; var MessageError : String; var BinaryBlob : TMemoryStream) : TJSONValue;
 Var
  vTempQuery      : TRESTDWDrvQuery;
  vTempJSON       : TJSONValue;
@@ -3739,7 +3659,7 @@ Begin
  vMetaData       := False;
  vCompatibleMode := False;
  bJsonArray      := Nil;
- vTempQuery      := getQuery;
+ vTempQuery      := getQuery(True);
  Try
   vStateResource := isConnected;
   If Not vStateResource Then
@@ -3846,12 +3766,8 @@ Begin
   FreeAndNil(bJsonValue);
 End;
 
-Function TRESTDWDriverBase.OpenDatasets(DatapackStream        : TStream;
-                                        Var Error             : Boolean;
-                                        Var MessageError      : String;
-                                        Var BinaryBlob        : TMemoryStream;
-                                        aBinaryEvent          : Boolean;
-                                        aBinaryCompatibleMode : Boolean): TStream;
+function TRESTDWDriverBase.OpenDatasets(
+  DatapackStream : TStream; var Error : Boolean; var MessageError : String; var BinaryBlob : TMemoryStream; aBinaryEvent : Boolean; aBinaryCompatibleMode : Boolean) : TStream;
 Var
  X               : Integer;
  vTempQuery      : TRESTDWDrvQuery;
@@ -3870,7 +3786,7 @@ Begin
  Error           := False;
  BufferInStream  := TRESTDWBufferBase.Create;
  BufferOutStream := TRESTDWBufferBase.Create;
- vTempQuery      := getQuery;
+ vTempQuery      := getQuery(True);
  Try
   BufferInStream.LoadToStream(DatapackStream);
   vStateResource := isConnected;
@@ -3969,15 +3885,14 @@ begin
     FServerMethod := TServerMethodDataModule(Self.Owner);
 end;
 
-Class Procedure TRESTDWDriverBase.CreateConnection(Const AConnectionDefs : TConnectionDefs;
-                                                   Var AConnection       : TComponent);
+class procedure TRESTDWDriverBase.CreateConnection(const AConnectionDefs : TConnectionDefs; var AConnection : TComponent);
 Begin
  If (Not Assigned(AConnection))     Or
     (Not Assigned(AConnectionDefs)) Then
   Exit;
 End;
 
-Procedure TRESTDWDriverBase.PrepareConnection(Var AConnectionDefs : TConnectionDefs);
+procedure TRESTDWDriverBase.PrepareConnection(var AConnectionDefs : TConnectionDefs);
 Begin
  If Assigned(OnPrepareConnection) Then
   OnPrepareConnection(AConnectionDefs);
@@ -4460,9 +4375,7 @@ begin
   end;
 end;
 
-Procedure TRESTDWDriverBase.BuildDatasetLine(var Query: TRESTDWDrvDataset;
-                                             Massivedataset: TMassivedatasetBuffer;
-                                             MassiveCache: Boolean);
+procedure TRESTDWDriverBase.BuildDatasetLine(var Query : TRESTDWDrvDataset; Massivedataset : TMassivedatasetBuffer; MassiveCache : Boolean);
 Var
  I, A              : Integer;
  vMasterField,

--- a/CORE/Source/Database_Drivers/uRESTDWFireDACDriver.pas
+++ b/CORE/Source/Database_Drivers/uRESTDWFireDACDriver.pas
@@ -4,7 +4,7 @@
 
 {
   REST Dataware .
-  Criado por XyberX (Gilbero Rocha da Silva), o REST Dataware tem como objetivo o uso de REST/JSON
+  Criado por XyberX (Gilberto Rocha da Silva), o REST Dataware tem como objetivo o uso de REST/JSON
  de maneira simples, em qualquer Compilador Pascal (Delphi, Lazarus e outros...).
   O REST Dataware também tem por objetivo levar componentes compatíveis entre o Delphi e outros Compiladores
  Pascal e com compatibilidade entre sistemas operacionais.
@@ -30,7 +30,8 @@ uses
   Classes, SysUtils, uRESTDWDriverBase, uRESTDWBasicTypes,
   FireDAC.Comp.Client, FireDAC.Comp.DataSet, FireDAC.Stan.StorageBin,
   FireDAC.Stan.Intf, FireDAC.Stan.Option, FireDAC.DApt.Intf, FireDAC.DApt,
-  FireDAC.Stan.Param, FireDAC.DatS, DB, uRESTDWBasicDB, uRESTDWProtoTypes, FireDAC.Phys.RESTDW;
+  FireDAC.Stan.Param, FireDAC.DatS, DB, uRESTDWBasicDB, uRESTDWProtoTypes,
+  FireDAC.Phys.RESTDW;
 
 const
   rdwFireDACDrivers : array[0..17] of string = (('ads'),('asa'),('db2'),('ds'),
@@ -97,6 +98,7 @@ type
     Function compConnIsValid(comp : TComponent) : boolean; override;
   public
     function getQuery : TRESTDWDrvQuery; override;
+    function getQuery(AUnidir : boolean) : TRESTDWDrvQuery; override;
     function getTable : TRESTDWDrvTable; override;
     function getStoreProc : TRESTDWDrvStoreProc; override;
 
@@ -208,6 +210,16 @@ begin
   qry.FetchOptions.Mode            := fmAll;
 
   Result := TRESTDWFireDACQuery.Create(qry);
+end;
+
+function TRESTDWFireDACDriver.getQuery(AUnidir : boolean) : TRESTDWDrvQuery;
+var
+  qry : TFDQuery;
+begin
+
+  Result := inherited getQuery(AUnidir);
+  qry := TFDQuery(Result.Owner);
+  qry.FetchOptions.Unidirectional := AUnidir;
 end;
 
 function TRESTDWFireDACDriver.getTable : TRESTDWDrvTable;

--- a/CORE/Source/Database_Drivers/uRESTDWZeosDriver.pas
+++ b/CORE/Source/Database_Drivers/uRESTDWZeosDriver.pas
@@ -5,7 +5,7 @@
 
 {
   REST Dataware .
-  Criado por XyberX (Gilbero Rocha da Silva), o REST Dataware tem como objetivo o uso de REST/JSON
+  Criado por XyberX (Gilberto Rocha da Silva), o REST Dataware tem como objetivo o uso de REST/JSON
  de maneira simples, em qualquer Compilador Pascal (Delphi, Lazarus e outros...).
   O REST Dataware também tem por objetivo levar componentes compatíveis entre o Delphi e outros Compiladores
  Pascal e com compatibilidade entre sistemas operacionais.
@@ -37,7 +37,7 @@ uses
   {$ELSE}
     uRESTDWMemoryDataset,
   {$ENDIF}
-  Classes, SysUtils, DB,
+  Classes, SysUtils, DB, Variants,
   ZConnection, ZDataset, ZSequence, ZDbcIntfs, ZAbstractRODataset,
   ZAbstractDataset, ZStoredProcedure, ZEncoding, ZDatasetUtils,
   uRESTDWDriverBase, uRESTDWBasicTypes, uRESTDWProtoTypes, uRESTDWZeosPhysLink
@@ -115,6 +115,7 @@ type
     destructor Destroy; override;
 
     function getQuery : TRESTDWDrvQuery; override;
+    function getQuery(AUnidir : boolean) : TRESTDWDrvQuery; override;
     function getTable : TRESTDWDrvTable; override;
     function getStoreProc : TRESTDWDrvStoreProc; override;
 
@@ -184,6 +185,21 @@ begin
       Break;
     end;
     i := i + 1;
+  end;
+end;
+
+function TRESTDWZeosDriver.getQuery(AUnidir: boolean): TRESTDWDrvQuery;
+var
+  qry : TZReadOnlyQuery;
+begin
+  if AUnidir then begin
+    qry := TZReadOnlyQuery.Create(Self);
+    qry.IsUniDirectional := True;
+    qry.Connection := TZConnection(Connection);
+    Result := TRESTDWZeosQuery.Create(qry);
+  end
+  else begin
+    Result := inherited getQuery(AUnidir);
   end;
 end;
 
@@ -322,7 +338,7 @@ end;
 
 procedure TRESTDWZeosQuery.createSequencedField(seqname, field : string);
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
   if Trim(seqname) = '' then
     Exit;
@@ -330,19 +346,20 @@ begin
   if FSequence = nil then
     FSequence := TZSequence.Create(Self);
 
-  qry := TZQuery(Self.Owner);
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then begin
+    FSequence.SequenceName := seqname;
 
-  FSequence.SequenceName := seqname;
-
-  qry.Sequence := FSequence;
-  qry.SequenceField := field;
+    TZQuery(qry).Sequence := FSequence;
+    TZQuery(qry).SequenceField := field;
+  end;
 end;
 
 procedure TRESTDWZeosQuery.ExecSQL;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
+  qry := TZAbstractRODataset(Self.Owner);
   qry.ExecSQL;
 end;
 
@@ -357,12 +374,12 @@ end;
 procedure TRESTDWZeosQuery.LoadFromStreamParam(IParam: integer; stream: TStream;
   blobtype: TBlobType);
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
   {$IFDEF ZEOS80UP}
     cp : Word;
   {$ENDIF}
 begin
-  qry := TZQuery(Self.Owner);
+  qry := TZAbstractRODataset(Self.Owner);
   {$IFDEF ZEOS80UP}
     if BlobType in [ftWideString{$IFDEF WITH_WIDEMEMO}, ftFixedWideChar, ftWideMemo{$ENDIF}] then
       qry.Params[IParam].LoadTextFromStream(Stream, zCP_UTF16)
@@ -373,16 +390,19 @@ begin
       qry.Params[IParam].LoadTextFromStream(Stream, cp);
     end;
   {$ELSE}
-    qry.Params[IParam].LoadFromStream(stream,blobtype);
+    if qry is TZQuery then
+      TZQuery(qry).Params[IParam].LoadFromStream(stream,blobtype)
+    else if qry is TZReadOnlyQuery then
+      TZReadOnlyQuery(qry).Params[IParam].LoadFromStream(stream,blobtype)
   {$ENDIF}
 end;
 
 procedure TRESTDWZeosQuery.Prepare;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
   inherited Prepare;
-  qry := TZQuery(Self.Owner);
+  qry := TZAbstractRODataset(Self.Owner);
   qry.Prepare;
 end;
 
@@ -395,71 +415,97 @@ end;
 
 function TRESTDWZeosQuery.RowsAffected: Int64;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
+  qry := TZAbstractRODataset(Self.Owner);
   Result := qry.RowsAffected;
 end;
 
 function TRESTDWZeosQuery.ParamCount : Integer;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
-  Result := qry.Params.Count;
+  Result := 0;
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then
+    Result := TZQuery(qry).Params.Count
+  else if qry is TZReadOnlyQuery then
+    Result := TZReadOnlyQuery(qry).Params.Count;
 end;
 
 function TRESTDWZeosQuery.getParamDataType(IParam : integer) : TFieldType;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
-  Result := qry.Params[IParam].DataType;
+  Result := ftUnknown;
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then
+    Result := TZQuery(qry).Params[IParam].DataType
+  else if qry is TZReadOnlyQuery then
+    Result := TZReadOnlyQuery(qry).Params[IParam].DataType;
 end;
 
 function TRESTDWZeosQuery.getParamName(IParam : integer) : string;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
-  Result := qry.Params[IParam].Name;
+  Result := '';
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then
+    Result := TZQuery(qry).Params[IParam].Name
+  else if qry is TZReadOnlyQuery then
+    Result := TZReadOnlyQuery(qry).Params[IParam].Name;
 end;
 
 function TRESTDWZeosQuery.getParamSize(IParam : integer) : integer;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
-  Result := qry.Params[IParam].Size;
+  Result := 0;
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then
+    Result := TZQuery(qry).Params[IParam].Size
+  else if qry is TZReadOnlyQuery then
+    Result := TZReadOnlyQuery(qry).Params[IParam].Size;
 end;
 
 function TRESTDWZeosQuery.getParamValue(IParam : integer) : variant;
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
-  Result := qry.Params[IParam].Value;
+  Result := null;
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then
+    Result := TZQuery(qry).Params[IParam].Value
+  else if qry is TZReadOnlyQuery then
+    Result := TZReadOnlyQuery(qry).Params[IParam].Value;
 end;
 
 procedure TRESTDWZeosQuery.setParamDataType(IParam : integer; AValue : TFieldType);
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
-  qry.Params[IParam].DataType := AValue;
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then
+    TZQuery(qry).Params[IParam].DataType := AValue
+  else if qry is TZReadOnlyQuery then
+    TZReadOnlyQuery(qry).Params[IParam].DataType := AValue;
 end;
 
 procedure TRESTDWZeosQuery.setParamValue(IParam : integer; AValue : variant);
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
 begin
-  qry := TZQuery(Self.Owner);
-  qry.Params[IParam].Value := AValue;
+  qry := TZAbstractRODataset(Self.Owner);
+  if qry is TZQuery then
+    TZQuery(qry).Params[IParam].Value := AValue
+  else if qry is TZReadOnlyQuery then
+    TZReadOnlyQuery(qry).Params[IParam].Value := AValue;
 end;
 
 procedure TRESTDWZeosQuery.SaveToStream(stream: TStream);
 var
-  qry : TZQuery;
+  qry : TZAbstractRODataset;
   {$IFDEF ZMEMTABLE_ENABLE_STREAM_EXPORT_IMPORT}
     memtable : TZMemTable;
   {$ELSE}
@@ -478,8 +524,7 @@ begin
     {$ELSE}
       memtable.Assign(qry);
     {$ENDIF}
-    // TODO -oXyberX -cMemTable: Função SaveToStream não existe no TRESTDWMemtable
-//    memtable.SaveToStream(stream);
+    memtable.SaveToStream(stream);
     stream.Position := 0;
   finally
     FreeAndNil(memtable);
@@ -540,8 +585,7 @@ begin
     {$ELSE}
       memtable.Assign(qry);
     {$ENDIF}
-    // TODO -oXyberX -cMemTable: Função SaveToStream não existe no TRESTDWMemtable
-//    memtable.SaveToStream(stream);
+    memtable.SaveToStream(stream);
     stream.Position := 0;
   finally
     FreeAndNil(memtable);

--- a/CORE/Source/Plugins/Memdataset/uRESTDWMemoryDataset.pas
+++ b/CORE/Source/Plugins/Memdataset/uRESTDWMemoryDataset.pas
@@ -193,7 +193,6 @@ type
     FCaseInsensitiveSort: Boolean;
     FIndexList : TStringList;
     FLastID : integer;
-    FListFieldsDefs : TList;
 
     FStatusRecord : TRESTDWRecordStatus;
     FStatusRecordChanged : Boolean;
@@ -227,12 +226,6 @@ type
     function GetRecNo: integer; override;
     function GetRecordCount: integer; override;
     procedure SetRecNo(Value: Integer); override;
-
-    // locate
-    function Locate(const KeyFields: string; const KeyValues: Variant;
-      Options: TLocateOptions): Boolean; override;
-    function Lookup(const KeyFields: string; const KeyValues: Variant;
-      const ResultFields: string): Variant; override;
 
     // filter
     function FilterRecord(Buffer : TRESTDWBuffer): Boolean;
@@ -314,10 +307,15 @@ type
     function calcFieldSize(ft : TFieldType; fs : integer) : integer;
     procedure clearRecords;
     procedure clearBlobs;
-    procedure clearFieldsDefs;
   public
     constructor Create(AOwner : TComponent); override;
     destructor Destroy; override;
+
+    // locate
+    function Locate(const KeyFields: string; const KeyValues: Variant;
+      Options: TLocateOptions): Boolean; override;
+    function Lookup(const KeyFields: string; const KeyValues: Variant;
+      const ResultFields: string): Variant; override;
 
     {$IF (NOT DEFINED(FPC)) AND (CompilerVersion >= 21)}
       function GetFieldData(Field: TField; var Buffer: TValueBuffer): Boolean; override;
@@ -382,6 +380,9 @@ type
 implementation
 
 uses
+  {$IFDEF FPC}
+    bufstream,
+  {$ENDIF}
   uRESTDWStorageBin;
 
 procedure TRESTDWMemTable.InternalOpen;
@@ -420,6 +421,9 @@ procedure TRESTDWMemTable.InternalClose;
 var
   vBlock : Boolean;
 begin
+  if not FIsTableOpen then
+    Exit;
+
   vBlock := FBlockEvents;
   FBlockEvents := False;
 
@@ -917,13 +921,13 @@ var
 
   vCurrency : Currency;
   vDouble : Double;
-  vByte : Byte;
   vFmtBCD : tBCD;
   vTimeStamp : TTimeStamp;
   vDateTimeRec : TDateTimeRec;
   vString : AnsiString;
   {$IFNDEF FPC}
     vSQLTimeStamp : TSQLTimeStamp;
+    vByte : Byte;
   {$ENDIF}
   {$IF (NOT DEFINED(FPC)) AND (CompilerVersion >= 21)}
     vTimeStampOffSet : TSQLTimeStampOffSet;
@@ -1066,12 +1070,12 @@ var
 
   vCurrency : Currency;
   vDouble : Double;
-  vByte : Byte;
   vFmtBCD : tBCD;
   vDateTimeRec : TDateTimeRec;
   vTimeStamp : TTimeStamp;
   {$IFNDEF FPC}
     vSQLTimeStamp : TSQLTimeStamp;
+    vByte : Byte;
   {$ENDIF}
 
   {$IF (NOT DEFINED(FPC)) AND (CompilerVersion >= 21)}
@@ -1322,6 +1326,9 @@ begin
   clearBlobs;
   clearRecords;
 
+  SetState(vState);
+  DataEvent(deDataSetChange, 0);
+
   SetLength(FFieldOffsets,0);
   SetLength(FFieldSize,0);
   FRecordCount := 0;
@@ -1330,9 +1337,6 @@ begin
   FRecordBufferSize := 0;
   FRecordSize := 0;
   FFilterBuffer := nil;
-
-  SetState(vState);
-  DataEvent(deDataSetChange, 0);
 end;
 
 procedure TRESTDWMemTable.SaveToStream(AStream: TStream);
@@ -1608,8 +1612,6 @@ begin
           vFieldDef.DataType := Fields[i].DataType;
           vFieldDef.Size := Fields[i].Size;
           vFieldDef.Attributes := [faFixed];
-
-          FListFieldsDefs.Add(vFieldDef);
         end;
       end;
     end;
@@ -1756,6 +1758,8 @@ var
   i : integer;
   vBlob : PRESTDWBlobField;
 begin
+  if FBlobs = nil then
+    Exit;
   // eh mais rapido correr a lista ao contrario
   // pq nao tem que fazer deslocamento
   i := FBlobs.Count - 1;
@@ -1770,26 +1774,13 @@ begin
   FBlobs.Clear;
 end;
 
-procedure TRESTDWMemTable.clearFieldsDefs;
-var
-  i : integer;
-begin
-  // eh mais rapido correr a lista ao contrario
-  // pq nao tem que fazer deslocamento
-
-  i := FListFieldsDefs.Count - 1;
-  while i >= 0 do begin
-    TObject(FListFieldsDefs.Items[i]).Free;
-    FListFieldsDefs.Delete(i);
-    i := i - 1;
-  end;
-end;
-
 procedure TRESTDWMemTable.clearRecords;
 var
   i : integer;
   obj : TRESTDWRecord;
 begin
+  if FRecords = nil then
+    Exit;
   // eh mais rapido correr a lista ao contrario
   // pq nao tem que fazer deslocamento
   i := FRecords.Count - 1;
@@ -1852,18 +1843,17 @@ end;
 
 constructor TRESTDWMemTable.Create(AOwner: TComponent);
 begin
+  inherited Create(AOwner);
   FStatusRecord := rsInserted;
   FStatusRecordChanged := False;
   FRecordCount := 0;
   FFilterRecordCount := -1;
   FRecords := TList.Create;
   FBlobs := TList.Create;
-  FListFieldsDefs := TList.Create;
   FIndexList := nil;
   FFilterBuffer := nil;
   FFilterParser := nil;
   FStorageDataType := nil;
-  inherited Create(AOwner);
 end;
 
 function TRESTDWMemTable.CreateBlobStream(Field: TField;
@@ -1921,15 +1911,12 @@ begin
   if FFilterParser <> nil then
     FreeAndNil(FFilterParser);
 
-  clearFieldsDefs;
-
-  FieldDefs.Clear;
   Fields.Clear;
+  FieldDefs.Clear;
 
   FreeIndexList;
   FreeAndNil(FRecords);
   FreeAndNil(FBlobs);
-  FreeAndNil(FListFieldsDefs);
 
   inherited Destroy;
 end;
@@ -2151,9 +2138,11 @@ begin
   repeat
     if Filtered then begin
       vRec := GetRecordObj(FCurrentRecord);
-      vBuffer := vRec.CopyBuffer;
-      Accept := FilterRecord(vBuffer);
-      FreeMem(vBuffer);
+      if vRec <> nil then begin
+        vBuffer := vRec.CopyBuffer;
+        Accept := FilterRecord(vBuffer);
+        FreeMem(vBuffer);
+      end;
     end;
     if not Accept then
       Dec(FCurrentRecord);
@@ -2206,7 +2195,6 @@ end;
 procedure TRESTDWMemTable.InternalPost;
 var
   vRec : TRESTDWRecord;
-  vRecs : Integer;
 begin
   inherited InternalPost;
 
@@ -2254,7 +2242,6 @@ var
   i : integer;
   vFieldOffSet : integer;
   vBlobField : PRESTDWBlobField;
-  vField : TField;
   vBuf : TRESTDWBuffer;
   vBoolean : boolean;
   vDWFieldType : Byte;
@@ -2388,6 +2375,8 @@ end;
 destructor TRESTDWBlobStream.Destroy;
 begin
   SetDataBlob;
+  FDataset := nil;
+  FField := nil;
   inherited Destroy;
 end;
 
@@ -2397,6 +2386,7 @@ begin
   FreeMem(FBlobField^.Buffer, FBlobField^.Size);
   FBlobField^.Buffer := nil;
   FBlobField^.Size := 0;
+  FBlobField := nil;
   FModified := True;
 end;
 
@@ -2526,14 +2516,16 @@ end;
 
 procedure TRESTDWStorageBase.SaveToFile(ADataset: TDataset; AFileName: String);
 var
-  vFileStream : TFileStream;
+  vFileStream : TBufferedFileStream;
 begin
   try
-    vFileStream := TFileStream.Create(AFileName,fmCreate);
+    vFileStream := TBufferedFileStream.Create(AFileName,fmCreate);
     try
       SaveToStream(ADataset,TStream(vFileStream));
     except
-
+      on e : Exception do begin
+        raise
+      end;
     end;
   finally
     vFileStream.Free;


### PR DESCRIPTION
- Implementado getQuery Unidirecional -> para export datasets
- RESTDWMemoryDataset - Retirado AV do Lazarus
- Funções de exportação de dados - readaptadas para funcionar com queries Unidirecional