### PR TITLE
Queries Unidirecional - falha exportação não BinaryRequest

### DIFF
--- a/CORE/Source/Basic/uRESTDWParams.pas
+++ b/CORE/Source/Basic/uRESTDWParams.pas
@@ -1631,7 +1631,8 @@ Begin
                    Result := Format('[%s]', [vLines]);
                  End;
   End;
-  bValue.First;
+  if not bValue.IsUniDirectional then
+    bValue.First;
  Finally
   bValue.EnableControls;
  End;


### PR DESCRIPTION
- Correção de Unidirecional para não BinaryRequest