### PR TITLE
Correção MasterDetail com parâmetros extras

### DIFF
--- a/CORE/Source/Basic/uRESTDWBasicDB.pas
+++ b/CORE/Source/Basic/uRESTDWBasicDB.pas
@@ -9940,6 +9940,7 @@ Var
    Begin
     If FindField(Value.Params[I].Name) <> Nil Then
      Begin
+      Value.Params[I].Clear;
       If Not Result Then
        Result := Not (Value.Params[I].Value = FindField(Value.Params[I].Name).Value) or (Value.Params[0].isnull);
       If ((Value.Params[I].Value = FindField(Value.Params[I].Name).Value)) And
@@ -9962,8 +9963,6 @@ Begin
    If vDetailClient <> Nil Then
     Begin
      vDetailClient.vInactive := False;
-     For J := 0 to vDetailClient.Params.Count -1 Do
-      vDetailClient.Params[J].Clear;
      If CloneDetails(vDetailClient) Then
       Begin
        vDetailClient.Active := False;


### PR DESCRIPTION
Correção MasterDetail com parâmetros extras.
Quanto um TRDWClientSQL está associado a outro com MasterDetail eles se ligam através dos paramentes, porém estava limpando parâmetros extras que não são campos na query principal.