### PR TITLE
Correção de memory Leak unit uRESTDWMessageCoderMIME.pas

### DIFF
--- a/CORE/Source/Basic/Mechanics/uRESTDWMessageCoderMIME.pas
+++ b/CORE/Source/Basic/Mechanics/uRESTDWMessageCoderMIME.pas
@@ -47,6 +47,7 @@ Uses
   Public
    Constructor Create             (AOwner      : TComponent;
                                    Const ALine : String); Reintroduce; Overload;
+   Destructor  Destroy;  Override;
    Function    ReadBody           (ADestStream : TStream;
                                    Var VMsgEnd : Boolean) : TRESTDWMessageDecoder; Override;
    Procedure   CheckAndSetType    (Const AContentType,
@@ -271,6 +272,11 @@ Begin
     End;
   End;
 End;
+
+destructor TRESTDWMessageDecoderMIME.Destroy;
+begin
+  inherited;
+end;
 
 Function TRESTDWMessageDecoderMIME.ReadBody(ADestStream : TStream;
                                             Var VMsgEnd : Boolean) : TRESTDWMessageDecoder;


### PR DESCRIPTION
Incluído "Destructor Destroy" na Classe TRESTDWMessageDecoderMIME.