### PR TITLE
Remoção Memory Leak do TRESTDWMemTable.

### DIFF
--- a/CORE/Source/Plugins/Memdataset/uRESTDWMemoryDataset.pas
+++ b/CORE/Source/Plugins/Memdataset/uRESTDWMemoryDataset.pas
@@ -2004,13 +2004,14 @@ end;
 
 destructor TRESTDWMemTable.Destroy;
 begin
+  if Self.Active then
+    Self.Close;
+
   if FFilterParser <> nil then
     FreeAndNil(FFilterParser);
 
   FreeIndexList;
   SetState(dsInactive);
-
-  //  DataEvent(deDataSetChange, 0);
 
   EmptyTable;
   FreeAndNil(FRecords);


### PR DESCRIPTION
Ao fechar a aplicação cliente, sem dar o Close na Tabela (ClientSQL), estava gerando memory leak.